### PR TITLE
build.sbt: Added ReloadOnSourceChanges

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import com.alexitc.ChromeSbtPlugin
 lazy val appName = "chrome-scalajs-template" // TODO: REPLACE ME
 lazy val isProductionBuild = sys.env.getOrElse("PROD", "false") == "true"
 
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
 val circe = "0.13.0"
 
 lazy val baseSettings: Project => Project = {


### PR DESCRIPTION
Added `Global / onChangedBuildSource := ReloadOnSourceChanges`.
This goes hand in hand with this piece of advice:

> Running sbt "~chromeUnpackedFast" will build the app each time it detects changes on the code

since it will trigger even when `AppManifest.scala`, which is part of the build definition, is changed.